### PR TITLE
Update of color variables pattern in colors.css file

### DIFF
--- a/assets/css/other/requirements/colors.css
+++ b/assets/css/other/requirements/colors.css
@@ -1,9 +1,7 @@
 :root {
-	--colors-bk-default: #FAFAFA;
+	--colors-default: #FAFAFA;
 
-	--colors-bk-white: #FFFFFF;
-	--colors-txt-white: #FFFFFF;
+	--colors-white: #FFFFFF;
 	
-	--colors-bk-black: #252525;
-	--colors-txt-black: #252525;
+	--colors-black: #252525;
 };


### PR DESCRIPTION
# CSS Color Variables
The names of the CSS color variables have been changed so that they are no longer redundant.
e.g.:
The variables:
*--colors-bk-default: #FAFAFA;*
*--colors-text-default: #FAFAFA;*
Were altered to one single variable:
*--colors-default: #FAFAFA.*